### PR TITLE
Improve wording of 'fork block' definition

### DIFF
--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -22,8 +22,8 @@ GetMedianTimePast(block.parent) call.
 "activation time": a block whose MTP is after this time
 shall comply with the new consensus rules introduced by this UAHF.
 
-"fork block": the first block in the active chain whose nTime is past the
-activation time.
+"fork block": the first block built on top of a chain tip whose MTP is
+greater than or equal to the activation time.
 
 "fork EB": the user-specified value that EB shall be set to at
 activation time. EB can be adjusted post-activation by the user.


### PR DESCRIPTION
It was pointed out that the definition of 'fork block' was a little unclear / imprecise.

Some more explanations / descriptions to aid understanding:

@deadalnix mentioned:

> There is a block at which MTP become greater than >= activation time. The next one is the fork block.

This spec's definition of the "fork block" makes it the first block to which the new consensus rules apply.
As per a common sense understanding of the term, it will be the block that forks the chain (because of the additional requirement that it must be > 1MB) .