### PR TITLE
Set 'fork id' to 0 as per current implementations

### DIFF
--- a/replay-protected-sighash.md
+++ b/replay-protected-sighash.md
@@ -1,6 +1,6 @@
 # BUIP-HF Digest for replay protected signature verification across hard forks
 
-Version 1.1, 2017-06-14
+Version 1.2, 2017-07-16
 
 ## Abstract
 
@@ -188,6 +188,12 @@ Gating code:
   }
 ````
 
+## Note
+
+In the UAHF, a `fork id` of 0 is used (see [[4]](#uahfspec) REQ-6-2 NOTE 4), i.e.
+the GetForkID() function returns zero.
+In that case the code can be simplified to omit the function.
+
 ## References
 
 <a name="bip143">[1]</a> https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
@@ -195,3 +201,5 @@ Gating code:
 <a name="bip143Motivation">[2]</a> https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#Motivation
 
 <a name="OP_CHECKSIG">[3]</a> https://en.bitcoin.it/wiki/OP_CHECKSIG
+
+<a name="uahfspec">[4]</a> https://github.com/Bitcoin-UAHF/spec/blob/master/uahf-technical-spec.md

--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -1,6 +1,6 @@
 # UAHF Technical Specification
 
-Version 1.3, 2017-06-29
+Version 1.4, 2017-07-16
 
 
 ## Introduction
@@ -184,6 +184,10 @@ constraint introduced by REQ-6-1.
 
 NOTE 3: If bit 6 is not set, only the unmodified nHashType will be used
 to compute the hash and verify the signature.
+
+NOTE 4: The magic 'fork id' value used by UAHF-compatible clients is zero.
+This means that the change in hash when bit 6 is set is effected only by
+the adapted signing algorithm (see REQ-6-3).
 
 
 ### REQ-6-3 (use adapted BIP143 hash algorithm for protected transactions)


### PR DESCRIPTION
The 'fork id' could be changed if needed, but a value of 0 works since
for transactions which set SIGHASH_FORKID, the adapted digest algorithm
is used, yielding a different signature.

A note is also added to the description of the new digest algorithm to
clarify that the GetForkID() function can be omitted in the UAHF, as it would
merely return 0 .

Specifying the GetForkID() function is still considered useful since the
document can remain applicable to chains which may want to set a non-zero
value as fork id.