### PR TITLE
Add optional NODE_BITCOIN_CASH service bit description

### DIFF
--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -1,6 +1,6 @@
 # UAHF Technical Specification
 
-Version 1.4, 2017-07-16
+Version 1.5, 2017-07-22
 
 
 ## Introduction

--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -232,14 +232,16 @@ node / make a decision at late stage without needing to change client.
 
 ### OPT-SERVICEBIT (NODE_BITCOIN_CASH service bit)
 
-The client should implement service bit 5 (value 0x20), further called
-NODE_BITCOIN_CASH and represented in short form as "CASH".
+A UAHF-compatible client should set service bit 5 (value 0x20).
 
 RATIONALE: This service bit allows signaling that the node is a UAHF
 supporting node, which helps DNS seeders distinguish UAHF implementations.
 
-NOTE: This is an optional feature which clients do not strictly have to
+NOTE 1: This is an optional feature which clients do not strictly have to
 implement.
+
+NOTE 2: This bit is currently referred to as NODE_BITCOIN_CASH and displayed
+as "CASH" in user interfaces of some Bitcoin clients (BU, ABC).
 
 
 ## References

--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -230,6 +230,18 @@ client with legacy chain / i.e. to decide to not follow the HF on one's
 node / make a decision at late stage without needing to change client.
 
 
+### OPT-SERVICEBIT (NODE_BITCOIN_CASH service bit)
+
+The client should implement service bit 5 (value 0x20), hencewith called
+NODE_BITCOIN_CASH and represented in short form as "CASH".
+
+RATIONALE: This service bit allows signaling that the node is a UAHF
+supporting node, which helps DNS seeders distinguish UAHF implementations.
+
+NOTE: This is an optional feature which clients do not strictly have to
+implement.
+
+
 ## References
 
 [1] https://bitco.in/forum/threads/buip040-passed-emergent-consensus-parameters-and-defaults-for-large-1mb-blocks.1643/

--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -232,7 +232,7 @@ node / make a decision at late stage without needing to change client.
 
 ### OPT-SERVICEBIT (NODE_BITCOIN_CASH service bit)
 
-The client should implement service bit 5 (value 0x20), hencewith called
+The client should implement service bit 5 (value 0x20), further called
 NODE_BITCOIN_CASH and represented in short form as "CASH".
 
 RATIONALE: This service bit allows signaling that the node is a UAHF


### PR DESCRIPTION
Clients do not have to implement this, but it helps other network software
distinguish UAHF nodes from non-UAHF nodes, and is thus helpful.