### PR TITLE
Make protected transactions mandatory on UAHF chain (and enforce SCRIPT_VERIFY_STRICTENC)

### DIFF
--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -176,9 +176,12 @@ of its expiry by itself.
 
 ### REQ-6-2 (mandatory signature shift via hash type)
 
-Once the fork has activated, a transaction shall be deemed invalid if
-its nHashType does not have bit 6 set (SIGHASH_FORKID, mask 0x40) and it
-is not using the new digest algorithm described in REQ-6-3.
+Once the fork has activated, a transaction shall be deemed valid only if
+the following are true in combination:
+- its nHashType has bit 6 set (SIGHASH_FORKID, mask 0x40)
+- a magic 'fork id' value is added to the nHashType before the hash is
+  calculated (see note 4)
+- it is digested using the new algorithm described in REQ-6-3
 
 RATIONALE: To provide strong protection against replay of existing
 transactions on the UAHF chain, only transactions signed with the new

--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -221,11 +221,15 @@ deployment.
 
 ### REQ-6-4 (mandatory use of SCRIPT_VERIFY_STRICTENC)
 
-Once the fork has activated, a transaction shall be deemed invalid if
-it does not have the SCRIPT_VERIFY_STRICTENC flag set.
+Once the fork has activated, transactions shall be validated with
+SCRIPT_VERIFY_STRICTENC flag set.
 
-RATIONALE: SCRIPT_VERIFY_STRICTENC ensure that the nHashType is validated
-properly.
+RATIONALE: Use of SCRIPT_VERIFY_STRICTENC also ensures that the
+nHashType is validated properly.
+
+NOTE: As SCRIPT_VERIFY_STRICTENC is not clearly defined by BIP,
+implementations seeking to be compliant should consult the Bitcoin C++
+source code to emulate the checks enforced by this flag.
 
 
 ### REQ-7 Difficulty adjustement in case of hashrate drop


### PR DESCRIPTION
This enforces the use of SIGHASH_FORKID and SCRIPT_VERIFY_STRICTENC on
by UAHF-compatible clients once the fork has activated.

It makes the OP_RETURN protection obsolete, but it is not removed in order
to avoid a hard fork change w.r.t. existing deployments.

The strengthening of replay protections is a feature requested by miners
and exchanges to protect Bitcoin users from accidental loss and theft of
their Bitcoin Cash.