### PR TITLE
Update november 13th technical details to include note about medians

### DIFF
--- a/nov-13-hardfork-spec.md
+++ b/nov-13-hardfork-spec.md
@@ -17,10 +17,10 @@ To calculate the difficulty of a given block (B_n+1), with an MTP-11[1] greater 
 * NOTE: Implementations must use integer arithmetic only
 
 1. Let B_n be the Nth block in a Bitcoin Cash Blockchain.
-1. Let B_last be the middle block of the [B_n, B_n-1, B_n-2] when sorted by timestamp.
-1. Let B_first be the middle block of the [B_n-144, B_n-145, B_n-146] when sorted by timestamp.
+1. Let B_last be the middle block[2] of the [B_n, B_n-1, B_n-2] when sorted by timestamp.
+1. Let B_first be the middle block[2] of the [B_n-144, B_n-145, B_n-146] when sorted by timestamp.
 1. Let the Timespan (TS) be equal to the difference in UNIX timestamps (in seconds) between B_last and B_first within the range [72 * 600, 288 * 600].  Values outside should be treated as their respective limit
-1. Let the Work Performed (W) be equal to the difference in chainwork[2] between B_last  and B_first.
+1. Let the Work Performed (W) be equal to the difference in chainwork[3] between B_last  and B_first.
 1. Let the Projected Work (PW) be equal to (W * 600) / TS.
 1. Let Target (T) be equal to the (2^256 - PW) / PW.  This is calculated by taking the two’s complement of PW (-PW) and dividing it by PW (-PW / PW).
 1. The target difficulty for block B_n+1 is then equal to the lesser of T and 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
@@ -40,4 +40,5 @@ A: Yes
 Footnotes
 ---------
 1. The MTP-11 of a block is defined as the median timestamp of the last 11 blocks prior to, and including, a specific block
-2. Chainwork for a Block (B) is the sum of block proofs from the genesis block to B.  Block proofs is defined in [chain.cpp](https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/chain.cpp#L132)
+2. If two timestamps are the same, the one with the greater block height will be used.  See [GetSuitableBlock](https://github.com/Bitcoin-ABC/bitcoin-abc/commit/be51cf295c239ff6395a0aa67a3e13906aca9cb2#diff-ba91592f703a9d0badf94e67144bc0aaR208)
+3. Chainwork for a Block (B) is the sum of block proofs from the genesis block to B.  Block proofs is defined in [chain.cpp](https://github.com/Bitcoin-ABC/bitcoin-abc/blob/d8eac91f8d16716eed0ad11ccac420122280bb13/src/chain.cpp#L132)


### PR DESCRIPTION
@kyuupichan pointed out that the Median needs to be defined exactly
for the case when timestamps are duplicated.  We should consider
updating the protocol to reject such blocks if they are not already
rejected.